### PR TITLE
manifest: Track specific revision of repohooks

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -681,7 +681,7 @@
   <project path="tools/metalava" name="platform/tools/metalava" groups="pdk,tools" remote="aosp" />
   <project path="tools/motodev" name="platform/tools/motodev" groups="notdefault,motodev" remote="aosp" />
   <project path="tools/ndkports" name="platform/tools/ndkports" groups="pdk" remote="aosp" />
-  <project path="tools/repohooks" name="platform/tools/repohooks" groups="adt-infra,cts,developers,motodev,pdk,tools,tradefed" remote="aosp" revision="master" />
+  <project path="tools/repohooks" name="platform/tools/repohooks" groups="adt-infra,cts,developers,motodev,pdk,tools,tradefed" remote="aosp" revision="f485d175b804334112409240d77a9d1821420a95" />
   <project path="tools/security" name="platform/tools/security" groups="pdk,tools" remote="aosp" />
   <project path="tools/studio/cloud" name="platform/tools/studio/cloud" groups="notdefault,tools" remote="aosp" />
   <project path="tools/swt" name="platform/tools/swt" groups="notdefault,tools" remote="aosp" />


### PR DESCRIPTION
* 17.1/18.1/19.1 all track `master` for this repo.
* 17.1 is the only one of these where soong lacks license declaration support, so as of March, 2025 17.1 builds all fail.
* Roll this repo back two commits, to before the license declaration was added.

This means that 17.1 repohooks will be frozen @:

```
commit f485d175b804334112409240d77a9d1821420a95
Merge: ee097dd 9faea55
Author: Mike Frysinger <vapier@google.com>
Date:   Thu Feb 20 09:23:17 2025 -0800

    tools: cpplint: update to 2.0.0 release am: 9faea55166

    Original change: https://android-review.googlesource.com/c/platform/tools/repohooks/+/3499431

    Change-Id: Ie68e5b1d813da2e1e6b660891c7064c799c0bd48
    Signed-off-by: Automerger Merge Worker <android-build-automerger-merge-worker@system.gserviceaccount.com>
```

Reference: I5ae3aedfce2596db7eb4d7d41842d94fd3be21bf
Change-Id: If8caab90c834221192de53e61db9bfb0e7fe6bfc